### PR TITLE
Return empty DevicePluginOptions instead of nil

### DIFF
--- a/socketcan.go
+++ b/socketcan.go
@@ -322,7 +322,7 @@ func (scdp *SocketCANDevicePlugin) Allocate(ctx context.Context, r *pluginapi.Al
 // GetDevicePluginOptions returns options to be communicated with Device
 // Manager.
 func (SocketCANDevicePlugin) GetDevicePluginOptions(context.Context, *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
-	return nil, nil
+	return &pluginapi.DevicePluginOptions{}, nil
 }
 
 // PreStartContainer is called, if indicated by Device Plugin during registeration phase,


### PR DESCRIPTION
Fixes segfault when using physical CAN interface